### PR TITLE
Fix to support babel 5 transpiler

### DIFF
--- a/lib/Hit.js
+++ b/lib/Hit.js
@@ -2,10 +2,11 @@ var Serializable = require('./Serializable');
 
 class Hit extends Serializable {
 
-  constructor(properties, experiment) {
+  constructor(type, properties, experiment) {
     super();
     this.set(properties);
-    this.properties.t = this.type;
+    this.properties.t = type;
+    this.type = type;
     if (experiment) {
       this.set(experiment.toObject());
     }

--- a/lib/hits/Event.js
+++ b/lib/hits/Event.js
@@ -2,8 +2,7 @@ var Hit = require('../Hit');
 
 class Event extends Hit {
   constructor(category, action, label, value, experiment) {
-    this.type = 'event';
-    super({
+    super('event', {
       ec: category,
       ea: action,
       el: label,

--- a/lib/hits/Exception.js
+++ b/lib/hits/Exception.js
@@ -2,8 +2,7 @@ var Hit = require('../Hit');
 
 class Exception extends Hit {
   constructor(description, isFatal, experiment) {
-    this.type = 'exception';
-    super({
+    super('exception', {
       exd: description,
       exf: isFatal
     });

--- a/lib/hits/PageView.js
+++ b/lib/hits/PageView.js
@@ -2,8 +2,7 @@ var Hit = require('../Hit');
 
 class PageView extends Hit {
   constructor(hostname, page, title, experiment) {
-    this.type = 'pageview';
-    super({
+    super('pageview', {
       dh: hostname,
       dp: page,
       dt: title

--- a/lib/hits/ScreenView.js
+++ b/lib/hits/ScreenView.js
@@ -2,8 +2,7 @@ var Hit = require('../Hit');
 
 class ScreenView extends Hit {
   constructor(appName, appVersion, appId, appInstallerId, screenName, experiment) {
-    this.type = 'screenview';
-    super({
+    super('screenview', {
       an: appName,
       av: appVersion,
       aid: appId,

--- a/lib/hits/Social.js
+++ b/lib/hits/Social.js
@@ -2,8 +2,7 @@ var Hit = require('../Hit');
 
 class Social extends Hit {
   constructor(action, network, target, experiment) {
-    this.type = 'social';
-    super({
+    super('social', {
       sa: action,
       sn: network,
       st: target

--- a/lib/hits/Timing.js
+++ b/lib/hits/Timing.js
@@ -2,8 +2,7 @@ var Hit = require('../Hit');
 
 class Timing extends Hit {
   constructor(category, variable, time, label, experiment) {
-    this.type = 'timing';
-    super({
+    super('timing', {
       utc: category,
       utv: variable,
       utt: time,


### PR DESCRIPTION
Babel 5 throws an error if `this` is accessed before the `super()` call. This PR fixes this condition.
