### PR TITLE
Don't add null-ish properties to query string

### DIFF
--- a/lib/Serializable.js
+++ b/lib/Serializable.js
@@ -16,7 +16,7 @@ class Serializable {
     var str = [];
     var obj = this.toObject();
     for(var p in obj) {
-      if (obj.hasOwnProperty(p)) {
+      if (obj.hasOwnProperty(p) && obj[p]) {
         str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
       }
     }


### PR DESCRIPTION
Hey there!

I noticed I ran into issues if any of the parameters passed to a Hit object were `null` or `undefined`, bad times occurred.

This patch fixed it!
