### PR TITLE
Remove peerDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   "description": "Google Analytics for React Native!",
   "main": "index.js",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
-  "peerDependencies": {
-    "react-native": "*"
-  },
   "keywords": [
     "react",
     "native",


### PR DESCRIPTION
```
npm install react-native-google-analytics@latest --save
```

Run the command above resulted the following error:

```
npm WARN peerDependencies The peer dependency react-native@* included from react-native-google-analytics will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm ERR! Darwin 15.0.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "react-native-google-analytics@latest" "--save"
npm ERR! node v4.2.2
npm ERR! npm  v2.14.7
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package react-native@0.16.0-rc does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-native-google-analytics@0.0.4 wants react-native@*
```
