### PR TITLE
Reordering arguments of ScreenView

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ var rnabtest = React.createClass({
       // https://github.com/rebeccahughes/react-native-device-info has an implementation of obtaining a client ID,
       // their getUniqueId() method should do the job
       ga = new Analytics('UA-XXXXXXXX-X', clientId);
-      var screenView = new GAHits.ScreenView('GA Test', '1', 'com.example.app');
+      var screenView = new GAHits.ScreenView('Example App', 'Welcome Screen' '1', 'com.example.app');
       ga.send(screenView);
     });
   },

--- a/lib/hits/ScreenView.js
+++ b/lib/hits/ScreenView.js
@@ -1,13 +1,13 @@
 var Hit = require('../Hit');
 
 class ScreenView extends Hit {
-  constructor(appName, appVersion, appId, appInstallerId, screenName, experiment) {
+  constructor(appName, screenName, appVersion, appId, appInstallerId, experiment) {
     super('screenview', {
       an: appName,
+      cd: screenName,
       av: appVersion,
       aid: appId,
-      aiid: appInstallerId,
-      cd: screenName
+      aiid: appInstallerId
     }, experiment);
   }
 }


### PR DESCRIPTION
Moving required arguments of Screenview() to be first. (GA requires `an`
and `cd` arguments.)

Fixes #21
