### PR TITLE
Allow for custom user agent.

### DIFF
--- a/lib/Analytics.js
+++ b/lib/Analytics.js
@@ -1,8 +1,9 @@
 class Analytics {
-  constructor(trackingId, clientId, version) {
+  constructor(trackingId, clientId, version, userAgent) {
     this.version = version || 1;
     this.trackingId = trackingId;
     this.clientId = clientId;
+    this.userAgent = userAgent || null;
   }
 
   send(hit) {
@@ -13,9 +14,17 @@ class Analytics {
       cid: this.clientId
     });
 
-    fetch('https://ssl.google-analytics.com/collect?' + hit.toQueryString() + '&z=' + Math.round(Math.random() * 1e8), {
+    let options = {
       method: 'get',
-    });
+    }
+
+    if (this.userAgent) {
+      options.headers = {
+        'user-agent': this.userAgent
+      };
+    }
+
+    fetch('https://ssl.google-analytics.com/collect?' + hit.toQueryString() + '&z=' + Math.round(Math.random() * 1e8), options);
   }
 }
 


### PR DESCRIPTION
This lets the end user provide the user agent to pass. Reason: React Native is currently passing okhttp for android and I am not sure what for iOS at this moment off the top of my head. This doesn't tell GA very much info. This hand-in-hand with https://github.com/rebeccahughes/react-native-device-info/pull/13 gives users the ability to report the REAL user agent and thus get better information out of GA.
