### PR TITLE
Update README.md, there was a syntax error in the example codes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ var rnabtest = React.createClass({
   componentWillMount() {
     let clientId = DeviceInfo.getUniqueID();
     ga = new Analytics('UA-XXXXXXXX-X', clientId);
-    var screenView = new GAHits.ScreenView('Example App', 'Welcome Screen' '1', 'com.example.app');
+    var screenView = new GAHits.ScreenView('Example App', 'Welcome Screen', '1', 'com.example.app');
     ga.send(screenView);
   },
 


### PR DESCRIPTION
Noticed this from my copy pastas:

from:

``` js
  var screenView = new GAHits.ScreenView('Example App', 'Welcome Screen' '1', 'com.example.app');  
```

to:

``` js
 var screenView = new GAHits.ScreenView('Example App', 'Welcome Screen', '1', 'com.example.app');
```
