### PR TITLE
Recommend firebase analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Google Analytics for React Native!
 
+> 🚨 Check out [`expo-firebase-analytics`](https://docs.expo.io/versions/latest/sdk/firebase-analytics/) for universal React support (iOS, Android, web, & Electron).
+
 ## Getting started
 
 1. `npm install react-native-google-analytics@latest --save`


### PR DESCRIPTION
As [Firebase analytics](https://firebase.google.com/products/analytics) and Google analytics merge closer together, we can start recommending the better maintained expo-firebase-analytics package
